### PR TITLE
Make position of PV inverter configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ git clone https://github.com/schenlap/venus_kostal_pico.git on your local comput
 Edit kostal.ini and add your credentials.
 ```
 [KOSTAL]
-ip = http://10.0.0.50 # yout ip adress
+ip = http://10.0.0.50 # your ip adress
 username = pvserver
 password = xxxx
 intervall = 10 # seconds
 version = 1
+# 0 for AC-IN1, 1 for AC-OUT, 2 FOR AC-IN2
+position = 0
 ```
 ## Kostal version 2 devices
 Version 2 devices respond on ```http://<IP>/measurements.xml``` with a xml page like
@@ -42,19 +44,23 @@ Version 2 devices respond on ```http://<IP>/measurements.xml``` with a xml page 
 Edit kostal.ini and set version 2.
 ```
 [KOSTAL]
-ip = http://10.0.0.50 # yout ip adress
+ip = http://10.0.0.50 # your ip adress
 intervall = 10 # seconds
 version = 2
+# 0 for AC-IN1, 1 for AC-OUT, 2 FOR AC-IN2
+position = 0
 ```
 ## Kostal version 3 devices
 For version 3 devices there are no login credentials necessary, leave them blank. You can test if yoh have a version 3 device if you enter ```http:<IP>/api/dxs.json?dxsEntries=67109120``` in the browser. If you don't get an error you have a version 3 device.
 ```
 [KOSTAL]
-ip = http://10.0.0.50 # yout ip adress
+ip = http://10.0.0.50 # your ip adress
 username =
 password =
 intervall = 10 # seconds
 version = 3
+# 0 for AC-IN1, 1 for AC-OUT, 2 FOR AC-IN2
+position = 0
 ```
 
 ## Kostal plenticore devices
@@ -81,14 +87,14 @@ and copy all files
 scp venus_kostal_pico/* root@venusip:/data/venus_kostal_pico/
 ```
 
-## VELib pyhton
+## VELib python
 VElib is necessary. Link the whole velib_python directory somewhere from venus into the directory of venus_kostal_pico or clone from https://github.com/victronenergy/velib_python.
 ```
 root@venus_pi2:/data/venus_kostal_pico# ln -s /opt/victronenergy/dbus-pump/ext/velib_python ./
 ```
 
 # Test
-You can test you script with /data/rc.local.  You should now see your inverter on venus display. To get same debug output you can start ```kosatal.py``` from the console. It should look something like this:
+You can test you script with /data/rc.local.  You should now see your inverter on venus display. To get same debug output you can start ```kostal.py``` from the console. It should look something like this:
 ```
 $ ./kostal.py 
 Using http://10.0.0.49:90 user: pvserver

--- a/kostal.ini
+++ b/kostal.ini
@@ -3,4 +3,7 @@ ip = http://10.0.0.10
 username = admin
 password = topsecret
 intervall = 10
-version = 1 #1 for old inverter, 3 for new
+# 1 for old inverter, 3 for new
+version = 1
+# 0 for AC-IN1, 1 for AC-OUT, 2 FOR AC-IN2
+position = 0

--- a/kostal.py
+++ b/kostal.py
@@ -108,6 +108,9 @@ def read_settings() :
 
 	if parser.has_option('KOSTAL', 'instance'):
 		Kostal.instance = int(parser.get('KOSTAL', 'instance'))
+	
+	if parser.has_option('KOSTAL', 'position'):
+		Kostal.position = int(parser.get('KOSTAL', 'position'))
 
 def kostal_read_example(filename) :
 	with open(filename) as f:
@@ -336,7 +339,7 @@ def kostal_data_read_cb( jsonstr ) :
 def kostal_status_read_cb( jsonstr, init) :
 	global kostal
 	if init:
-		kostal = KostalInverter(Kostal.inverter_name,'tcp:' + Kostal.ip, Kostal.instance,'0',  Kostal.inverter_name, '0.0','0.1')
+		kostal = KostalInverter(Kostal.inverter_name,'tcp:' + Kostal.ip, Kostal.instance,'0',  Kostal.inverter_name, '0.0','0.1', Kostal.position)
 		kostal.set('/Mgmt/intervall', Kostal.intervall, 1)
 	return
 

--- a/kostal.py
+++ b/kostal.py
@@ -111,6 +111,8 @@ def read_settings() :
 	
 	if parser.has_option('KOSTAL', 'position'):
 		Kostal.position = int(parser.get('KOSTAL', 'position'))
+	else:
+		Kostal.position = 0
 
 def kostal_read_example(filename) :
 	with open(filename) as f:

--- a/kostal_inverter.py
+++ b/kostal_inverter.py
@@ -27,7 +27,7 @@ from vedbus import VeDbusService
 class KostalInverter :
 	dbusservice = []
 
-	def __init__(self, dev, connection, instance, serial, product, firmwarev, pversion) :
+	def __init__(self, dev, connection, instance, serial, product, firmwarev, pversion, position) :
 		#VERSION = '0.1'
 
 		print(__file__ + " starting up")
@@ -54,7 +54,7 @@ class KostalInverter :
 		self.dbusservice.add_path('/Serial', serial)
 		self.dbusservice.add_path('/Connected', 1, writeable=True)
 		self.dbusservice.add_path('/ErrorCode', '(0) No Error')
-		self.dbusservice.add_path('/Position', 0)
+		self.dbusservice.add_path('/Position', position)
 
 		_kwh = lambda p, v: (str(v) + 'KWh')
 		_a = lambda p, v: (str(v) + 'A')


### PR DESCRIPTION
While PV inverters may be located on AC-IN, they can be connected to AC-OUT as well. Values are taken from [here](https://github.com/victronenergy/dbus_vebus_to_pvinverter/blob/master/dbus_vebus_to_pvinverter.py#L66) and position 1 was tested in own setup. 0 remains the default.
Without this change, VRM and remote console will show invalid power readings for AC-OUT connected inverters.